### PR TITLE
Use channel precedence instead of nodefaults

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: jupyter-flight-simulator
 channels:
-  - nodefaults
   - conda-forge
+  - defaults
 dependencies:
   - jpeg >=9b
   - gdal


### PR DESCRIPTION
Per the suggestion on https://github.com/conda-forge/gdal-feedstock/issues/126, use environment.yml channel precedence instead of `nodefaults` to ensure not getting `_nb_ext_conf`.

Validated locally, this generates:
```
Known nbextensions:
  config dir: xxx/jupyter/nbconfig
    notebook section
      jupyter-threejs/extension  enabled
      - Validating: OK
      jupyter-js-widgets/extension  enabled
      - Validating: OK
```

instead of:
```
Known nbextensions:
  config dir: xxx/etc/jupyter/nbconfig
    notebook section
      nb_conda/main  enabled
      - Validating: OK
      nbpresent/js/nbpresent.min  enabled
      - Validating: OK
      nb_anacondacloud/main  enabled
      - Validating: OK
      jupyter-js-widgets/extension  enabled
      - Validating: OK
    tree section
      nb_conda/tree  enabled
      - Validating: OK
```